### PR TITLE
Relative path in img.defaultuserpic

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -305,7 +305,7 @@ font-size:1.2em;
 
 
 img.defaultuserpic {
-content:url("/user/pix.php?file=/164/f1.jpg");
+content:url("../user/pix.php?file=/164/f1.jpg");
 border: 1px solid #fff;
 margin:0
 }


### PR DESCRIPTION
Make img.defaultuserpic url a relative path. Fixes broken profile images where Moodle sites are hosted inside sub-directories.
