### PR TITLE
CSS dynamic url for img.defaultuserpic

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -305,7 +305,7 @@ font-size:1.2em;
 
 
 img.defaultuserpic {
-content:url("/user/pix.php?file=/164/f1.jpg");
+content:url("[[pix:u/f1]]");
 border: 1px solid #fff;
 margin:0
 }


### PR DESCRIPTION
Convert fixed path to dynamic path for img.defaultuserpic url. Fixes broken default user image links; when Moodle is mounted in a sub-directory.
