### PR TITLE
Space character at the beginning of core_renderer.php breaks non-HTML…

### DIFF
--- a/classes/core_renderer.php
+++ b/classes/core_renderer.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 require_once($CFG->dirroot . '/theme/bootstrapbase/renderers.php');
 /**
  * @packagetheme_aardvark


### PR DESCRIPTION
… output

Hi, a customer using Aardvark noticed that their XLS, CSV and other reports are printed as text in the browser, not as downloaded files.

After exploring many options, I noticed that the bug only occurs with Aardvark, so I supposed that something breaks the output.

The space at the beginnig of core_renderer.php was the responsible. I erased it and the reports worked again.